### PR TITLE
Fix an issue when classes share the same name as an alias

### DIFF
--- a/src/AliasLoader.php
+++ b/src/AliasLoader.php
@@ -10,9 +10,19 @@ class AliasLoader implements AliasLoaderInterface
     private $aliases;
 
     /**
+     * @var array List of created aliases
+     */
+    private $aliased = [];
+
+    /**
      * @var bool Whether or not the loader has been registered
      */
     private $isRegistered = false;
+
+    /**
+     * @var bool Whether or not we are in our loader
+     */
+    private $loading = false;
 
     /**
      * @var string Namespace that the alias should be created in
@@ -59,8 +69,11 @@ class AliasLoader implements AliasLoaderInterface
             // Determine what namespace the alias should be loaded into, depending on the root namespace
             $namespace = ($this->rootNamespace === true) ? $namespace : $this->rootNamespace;
 
-            // Create the class alias
-            class_alias($this->aliases[$alias], $namespace . $alias);
+            // Create the class alias if not already aliased
+            if (!isset($this->aliased[$key = $namespace . $alias])) {
+                class_alias($this->aliases[$alias], $namespace . $alias);
+            }
+            $this->aliased[$key] = true;
         }
     }
 
@@ -77,6 +90,6 @@ class AliasLoader implements AliasLoaderInterface
         }
 
         // Register the `load()` method of this object as an autoloader
-        return $this->isRegistered = spl_autoload_register(array($this, 'load'), true, true);
+        return $this->isRegistered = spl_autoload_register(array($this, 'load'), true);
     }
 }

--- a/src/AliasLoader.php
+++ b/src/AliasLoader.php
@@ -72,8 +72,8 @@ class AliasLoader implements AliasLoaderInterface
             // Create the class alias if not already aliased
             if (!isset($this->aliased[$key = $namespace . $alias])) {
                 class_alias($this->aliases[$alias], $namespace . $alias);
+                $this->aliased[$key] = true;
             }
-            $this->aliased[$key] = true;
         }
     }
 

--- a/src/AliasLoader.php
+++ b/src/AliasLoader.php
@@ -20,11 +20,6 @@ class AliasLoader implements AliasLoaderInterface
     private $isRegistered = false;
 
     /**
-     * @var bool Whether or not we are in our loader
-     */
-    private $loading = false;
-
-    /**
      * @var string Namespace that the alias should be created in
      */
     private $rootNamespace = false;

--- a/tests/AliasLoaderTest.php
+++ b/tests/AliasLoaderTest.php
@@ -21,13 +21,12 @@ class AliasLoaderTest extends TestCase
         $loader->register('Fake\Foo');
 
         $this->assertTrue($loader->isRegistered());
-        $this->assertFirstLoader($loader);
     }
 
     public function testRegisteringIsIdempotent()
     {
         $loader = new AliasLoader();
-        
+
         $this->assertFalse($loader->isRegistered());
 
         $loader->register();
@@ -45,6 +44,46 @@ class AliasLoaderTest extends TestCase
 
         $foo = new \alias_foo();
         $this->assertInstanceOf(Foo::class, $foo);
+    }
+
+    public function testSameClassNameWithRootNamespacesLoadsCorrectClass()
+    {
+        $loader = new AliasLoader();
+        $loader->register(true);
+        $loader->addAlias('Bar', Foo::class);
+
+        $this->assertNotInstanceOf(Foo::class, $bar = new Fixture\Bar());
+        $this->assertTrue($bar->notFoo); // double check
+
+        $this->assertInstanceOf(Foo::class, new Bar());
+        $this->assertInstanceOf(Foo::class, new \Bar());
+    }
+
+    public function testSameClassNameWithoutRootNamespacesLoadsProperly()
+    {
+        $loader = new AliasLoader();
+        $loader->register();
+        $loader->addAlias('Bar', Foo::class);
+
+        $this->assertNotInstanceOf(Foo::class, $bar = new Fixture\Bar());
+        $this->assertTrue($bar->notFoo); // double check
+
+        $this->assertInstanceOf(Foo::class, new \Bar());
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage("Class 'Tests\\Bar' not found");
+        new Bar();
+    }
+
+    public function testAliasesCanOnlyBeRegisteredOnce()
+    {
+        $loader = new AliasLoader();
+        $loader->addAlias('test', 'test');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("The alias, test, has already been added and cannot be modified.");
+
+        $loader->addAlias('test', 'test');
     }
 
     protected function isAliasLoader(callable $callable): bool
@@ -65,19 +104,6 @@ class AliasLoaderTest extends TestCase
         $aliasLoaders = array_filter($autoloaders, [$this, 'isAliasLoader']);
 
         $this->assertCount(1, $aliasLoaders);
-    }
-
-    private function assertFirstLoader(AliasLoader $loader)
-    {
-        $autoloaders = spl_autoload_functions();
-        $firstLoader = $autoloaders[0];
-
-        $this->assertIsArray($firstLoader);
-
-        [$object, $method] = $firstLoader;
-
-        $this->assertEquals($loader, $object);
-        $this->assertEquals('load', $method);
     }
 }
 

--- a/tests/AliasLoaderTest.php
+++ b/tests/AliasLoaderTest.php
@@ -59,7 +59,7 @@ class AliasLoaderTest extends TestCase
         $this->assertInstanceOf(Foo::class, new \Bar());
     }
 
-    public function testSameClassNameWithoutRootNamespacesLoadsProperly()
+    public function testSameClassNameWithoutRootNamespacesLoadsCorrectClass()
     {
         $loader = new AliasLoader();
         $loader->register();

--- a/tests/Fixture/Bar.php
+++ b/tests/Fixture/Bar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Fixture;
+
+class Bar
+{
+    public $notFoo = true;
+}


### PR DESCRIPTION
I ran into an issue where a class that has the same name as an alias was not loading properly when using `register(true)` on the `AliasLoader`.

It appears that the `$prepend` argument being `true` is causing this to not resolve as I'm thinking it would.

https://github.com/lhsazevedo/restatic/blob/84b920cce9aa43ede0a6f0504b0fd0148bce1b85/src/AliasLoader.php#L80

```php
$loader = new AliasLoader();
$loader->register(true);
$loader->addAlias('Bar', Foo::class);

// with $prepend=true
new Fixture\Bar(); // = Tests\Foo
new \Bar();        // = Tests\Foo
new Bar();         // = Tests\Foo

// without $prepend=true
new Fixture\Bar(); // == Tests\Fixture\Bar
new \Bar();        // == Tests\Foo
new Bar();         // == Tests\Foo
```