### PR TITLE
Updated for PHP 8.4 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    name: Tests PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v3
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/src/ProxyManager.php
+++ b/src/ProxyManager.php
@@ -27,7 +27,7 @@ class ProxyManager
      * @param $container   Container that holds the actual instances
      * @param $aliasLoader Alias Loader object that stores and resolves
      */
-    public function __construct(ContainerInterface $container, AliasLoaderInterface $aliasLoader = null)
+    public function __construct(ContainerInterface $container, ?AliasLoaderInterface $aliasLoader = null)
     {
         $this->container = $container;
         $this->aliasLoader = $aliasLoader ?: new AliasLoader();


### PR DESCRIPTION
The `ProxyManager::__construct` parameter for the `AliasLoaderInterface` was defaulting to `null` but the type didn't allow null, this specifies `?AliasLoaderInterface`.

I also added a github workflow to run tests from PHP 7.2 - 8.4